### PR TITLE
Update info about Haxe

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following is a list of open source compilers that can generate C (or in some
 | [Genie](http://live.gnome.org/Genie) | Genie |
 | [GHC](https://www.haskell.org/ghc/) | Haskell | [C backend](https://downloads.haskell.org/~ghc/7.6.3/docs/html/users_guide/code-generators.html) documentation page.  |
 | [GnuCOBOL](http://open-cobol.sourceforge.net/) | COBOL 2014 with extensions | |
-| [Haxe](http://haxe.org) | Haxe | Targets C++, not C. |
+| [Haxe](http://haxe.org) | Haxe | Has separate C++ and C targets |
 | [Idris](http://www.idris-lang.org/) | Idris | A pure functional programming language with dependent types. |
 | [Ivory](http://ivorylang.org/) | Ivory | A Haskell eDSL for safe systems programming. |
 | [jhc](http://repetae.net/computer/jhc/) | Haskell 98 | The resulting code doesn't use a garbage collector. |


### PR DESCRIPTION
Modern Haxe has pure-C compilation target meant to run using the [HashLink](https://hashlink.haxe.org/) run-time library (in addition to its existing C++ target).