### PR TITLE
Add matiec

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following is a list of open source compilers that can generate C (or in some
 | [Kit](https://www.kitlang.org/) | Kit | A statically typed procedural language with manual MM, traits, pattern matching, and metaprogramming designed with game development in mind. |
 | [Language84](http://norstrulde.org/language84/) | Language84 | |
 | [mbeddr](http://mbeddr.com/) | mbeddr | A set of languages for embedded software engineering. |
+| [matiec](https://bitbucket.org/mjsousa/matiec) | ST, IL, SFC (IEC 61131) | A set of textual languages for PLC programming. |
 | [Mercury](http://www.mercurylang.org/) | Mercury | |
 | [MLton](http://mlton.org/) | Standard ML | |
 | [Monkey 2](http://monkeycoder.co.nz/) | Monkey 2 | Targets C++, not C. |


### PR DESCRIPTION
[Matiec](https://bitbucket.org/mjsousa/matiec/src/default/) is an open source compiler for the programming languages defined in the IEC 61131-3 standard that generates ANSI C code. These programming languages are mostly used in the industrial automation domain, to program PLCs (Programmable Logic Controllers).