### PR TITLE
Update information about Yaksha programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following is a list of open source compilers that can generate C (or in some
 | [wasm2c](https://github.com/WebAssembly/wabt/tree/master/wasm2c) | WebAssembly | C | Converts WASM files to C source and header. | [repo](https://github.com/WebAssembly/wabt/tree/master/wasm2c) |
 | [wasmdec](https://github.com/wwwg/wasmdec) | WebAssembly | C | Converts WebAssembly binaries to C. | [repo](https://github.com/wwwg/wasmdec) |
 | [wax](https://github.com/LingDong-/wax) | wax | C, C#, C++, Java, Lua, Python, Swift, TypeScript, WebAssembly | A language design for transpiling. | [web](https://github.com/LingDong-/wax) |
-| [Yaksha](https://yakshalang.github.io/) | Python | C | Transpiles "Python like" programming language to C | [web](https://yakshalang.github.io/) [repo](https://github.com/YakshaLang) [doc](https://yakshalang.github.io/documentation.html) |
+| [Yaksha](https://yakshalang.github.io/) | Yaksha | C | Compiles "Python like" programming language to C99. No Garbage collector (manual memory management). Builtin support for raylib & wasm4. Macro system is a lisp dialect (YakshaLisp) | [web](https://yakshalang.github.io/) [repo](https://github.com/YakshaLang) [doc](https://yakshalang.github.io/documentation.html) |
 | [Zephir](http://zephir-lang.com/) | Zephir | C | A language for writing PHP extensions. | [web](http://zephir-lang.com/) |
 | [ZZ](https://github.com/aep/zz) | ZZ (Drunk Octopus) | C | A safe dialect of C for embedded systems inspired by Rust. | [repo](https://github.com/aep/zz) |
 


### PR DESCRIPTION
Hi I'm the original author of the language. I have suggested some changes to Yaksha. 👍🏽 This should give a general idea about what it can do. 

Language does look like Python (as I find it pleasing) but not a Python transpiler. Has zero compatibility with CPython/PyPy etc. Also has no concept of GIL & can do system (posix, etc) threads.

YakshaLisp macro system is a completely different (lisp dialect) that lives in the Yaksha compiler --> allowing you to do compile time calculations for example.  YakshaLisp ismark-sweep garbage collected. While Yaksha is manually memory managed. (You can use defer to make it simpler).

Yaksha targets C99. 